### PR TITLE
Allow using local insight-api node

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,8 @@ $ ./hd-wallet-addrs.php
                          only works when outfile is specified.
                          
     --toshi=<url>       toshi server. defaults to https://bitcoin.toshi.io
-    --insight=<url>     insight server. defaults to https://insight.bitpay.com
+    --insight=<url>     insight server. defaults to https://insight.bitpay.com/api
+                        use http://localhost:3001/insight-api for local node
     
     --oracle-raw=<p>    path to save raw server response, optional.
     --oracle-json=<p>   path to save formatted server response, optional.

--- a/hd-wallet-addrs.php
+++ b/hd-wallet-addrs.php
@@ -125,7 +125,7 @@ function process_cli_params( $params ) {
     
     $params['api'] = @$params['api'] ?: 'blockchaindotinfo';
 
-    $params['insight'] = @$params['insight'] ?: 'https://insight.bitpay.com';
+    $params['insight'] = @$params['insight'] ?: 'https://insight.bitpay.com/api';
     $params['blockchaindotinfo'] = @@$params['blockchaindotinfo'] ?: 'https://blockchain.info';
     $params['toshi'] = @$params['toshi'] ?: 'https://bitcoin.toshi.io';
     $params['blockr'] = @$params['blockr'] ?: 'https://btc.blockr.io';
@@ -210,7 +210,7 @@ function print_help() {
                          only works when outfile is specified.
                          
     --toshi=<url>       toshi server. defaults to https://bitcoin.toshi.io
-    --insight=<url>     insight server. defaults to https://insight.bitpay.com
+    --insight=<url>     insight server. defaults to https://insight.bitpay.com/api
     
     --oracle-raw=<p>    path to save raw server response, optional.
     --oracle-json=<p>   path to save formatted server response, optional.

--- a/lib/blockchain_api.php
+++ b/lib/blockchain_api.php
@@ -150,7 +150,7 @@ class blockchain_api_insight  {
      */
     protected function get_address_info( $addr, $params ) {
         
-        $url_mask = "%s/api/addr/%s/?noTxList=1";
+        $url_mask = "%s/addr/%s/?noTxList=1";
         $url = sprintf( $url_mask, $params['insight'], $addr );
         
         mylogger()->log( "Retrieving addresses metadata from $url", mylogger::debug );


### PR DESCRIPTION
The hardcoded url mask didn’t allow for local insight-api nodes.

You can now use -—insight=http://localhost:3001/insight-api to use a local node.