### PR TITLE
Limit bitwasp version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dan-da/hd-wallet-addrs",
 
     "require": {
-        "bitwasp/bitcoin": ">=0.0.19",
+        "bitwasp/bitcoin": ">=0.0.19 <0.0.35",
         "ext-json": "*",
         "php": ">=5.5"
     },


### PR DESCRIPTION
0.0.35 and up returns "Call to undefined method
BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey::getAddress()"