### PR TITLE
add esplora as a parameter to be configured

### DIFF
--- a/hd-wallet-addrs.php
+++ b/hd-wallet-addrs.php
@@ -61,6 +61,7 @@ function get_cli_params() {
                                   'btcdotcom:',
                                   'blockcypher:',
                                   'insight:',
+                                  'esplora:',
                                   'api:', 
                                   'list-cols',
                                   'oracle-raw:', 'oracle-json:',


### PR DESCRIPTION
I forgot to add this in the last commit, now that I wanted hd-wallet-addr to point to my own esplora instance I added this line :)